### PR TITLE
Vercel validation should look at target, not subdomain

### DIFF
--- a/src/util/cnames.js
+++ b/src/util/cnames.js
@@ -87,7 +87,7 @@ const parseCNAMEsFile = (content, context = {}) => {
         if (subdomain.includes('.')) noCF = noCF || '// noCF';
 
         // Any Vercel subdomains must use noCF
-        if (subdomain === 'cname.vercel-dns.com') noCF = noCF || '// noCF';
+        if (target === 'cname.vercel-dns.com') noCF = noCF || '// noCF';
 
         cnames[subdomain] = {
             target,


### PR DESCRIPTION
Noticed this bug from #19 in https://github.com/js-org/js.org/pull/7807, the logic is looking for subdomains that are Vercel when it should actually be looking at the target.

`cnames_active.js` in js-org/js.org has no current violations of this validation change.