### PR TITLE
Strip trailing periods from entries

### DIFF
--- a/src/util/cnames.js
+++ b/src/util/cnames.js
@@ -56,16 +56,13 @@ const parseCNAMEsFile = (content, context = {}) => {
 
         // Drop any js.org suffix
         subdomain = subdomain.replace(/\.js\.org$/, '');
-
+        if (subdomain.endsWith('.')) subdomain = subdomain.slice(0, -1);
+        
         // Drop trailing slashes
         let target = match[2].replace(/\/+$/, '');
 
         // Drop trailing periods
-        const targetArr = target.split('.');
-        if (targetArr[targetArr.length - 1] === '') {
-            targetArr.splice(-1, 1);
-            target = targetArr.join('.');
-        }
+        if (target.endsWith('.')) target = target.slice(0, -1);
 
         // Drop http(s)://
         const urlMatch = target.match(/^(?:https?:)?\/\/(.+)$/i);

--- a/src/util/cnames.js
+++ b/src/util/cnames.js
@@ -60,6 +60,13 @@ const parseCNAMEsFile = (content, context = {}) => {
         // Drop trailing slashes
         let target = match[2].replace(/\/+$/, '');
 
+        // Drop trailing periods
+        const targetArr = target.split('.');
+        if (targetArr[targetArr.length - 1] === '') {
+            targetArr.splice(-1, 1);
+            target = targetArr.join('.');
+        }
+
         // Drop http(s)://
         const urlMatch = target.match(/^(?:https?:)?\/\/(.+)$/i);
         if (urlMatch) target = urlMatch[1];
@@ -139,13 +146,8 @@ const generateCNAMEsFile = (cnames, file) => {
     for (const i in cnamesKeys) {
         const cname = cnamesKeys[i];
         const data = cnames[cname];
-        
-        const target = data.target.split('.');
-        if(target[target.length - 1] === '') {
-            target.splice(-1, 1);
-        }
 
-        cnamesList.push(`  "${cname}": "${target.join('.')}"${Number(i) === cnamesKeys.length - 1 ? '' : ','}${data.noCF ? ` ${data.noCF}` : ''}`)
+        cnamesList.push(`  "${cname}": "${data.target}"${Number(i) === cnamesKeys.length - 1 ? '' : ','}${data.noCF ? ` ${data.noCF}` : ''}`)
     }
 
     // Format into the new file

--- a/src/util/cnames.js
+++ b/src/util/cnames.js
@@ -139,7 +139,13 @@ const generateCNAMEsFile = (cnames, file) => {
     for (const i in cnamesKeys) {
         const cname = cnamesKeys[i];
         const data = cnames[cname];
-        cnamesList.push(`  "${cname}": "${data.target}"${Number(i) === cnamesKeys.length - 1 ? '' : ','}${data.noCF ? ` ${data.noCF}` : ''}`)
+        
+        const target = data.target.split('.');
+        if(target[target.length - 1] === '') {
+            target.splice(-1, 1);
+        }
+
+        cnamesList.push(`  "${cname}": "${target.join('.')}"${Number(i) === cnamesKeys.length - 1 ? '' : ','}${data.noCF ? ` ${data.noCF}` : ''}`)
     }
 
     // Format into the new file


### PR DESCRIPTION
Strip trailing periods from entries for both `domain` and `subdomain`.

Resolves #27.